### PR TITLE
use https instead of http for uploading a new version to pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,12 @@ release:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
-	pip install twine
+	# Please install twine (`pip install twine`)
+	# in order to use https instead of http
+	# to upload a new version to pypi.
+	#
+	# https://twitter.com/glyph/status/580796504215924736
+	# https://pypi.python.org/pypi/twine
 
 	git checkout -b ${VERSION}-release master
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ release:
 ifndef VERSION
 	$(error VERSION is undefined)
 endif
+	pip install twine
 
 	git checkout -b ${VERSION}-release master
 
@@ -14,7 +15,7 @@ endif
 	git push origin ${VERSION}
 
 	# Package and upload to pypi
-	python setup.py sdist register upload
+	rm -rf dist && python setup.py sdist && twine upload dist/*
 
 	git checkout master
 	git branch -D ${VERSION}-release


### PR DESCRIPTION
Prefer https over http, based on:
- https://twitter.com/glyph/status/580796504215924736
- https://pypi.python.org/pypi/twine
