### PR TITLE
excluding tests from di-py package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://www.github.com/telefonicaid/di-py',
     author='Telefonica Digital',
     author_email='connect-dev@tid.es',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test*']),
     include_package_data=True,
     install_requires=[],
     tests_require=['nose', 'pyshould'],


### PR DESCRIPTION
The package is using a couple of files in  /usr/lib/python2.6/site-packages/tests/ which clash with package oauth. Neither should be using that directory anyways, so I'm issuing this PR so that tests are not included in the deliverable package.
