### PR TITLE
Task/version always in setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 	git checkout -b ${VERSION}-release master
 
-	sed -i '' -e 's/{VERSION}/${VERSION}/g' setup.py
+	sed -i '' -e "s/version='[^']*'/version='${VERSION}'/" setup.py
 	git add setup.py
 	git commit -m "Tagging version ${VERSION}"
 

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,14 @@ except ImportError:
     pass
 
 setup(
-    name='di-py',
-    description='Dependency injection library',
-    version='{VERSION}',
-    url='https://www.github.com/telefonicaid/di-py',
     author='Telefonica Digital',
     author_email='connect-dev@tid.es',
-    packages=find_packages(exclude=['test*']),
+    description='Dependency injection library',
     include_package_data=True,
     install_requires=[],
+    name='di-py',
+    packages=find_packages(exclude=['test*']),
+    url='https://www.github.com/telefonicaid/di-py',
     tests_require=['nose', 'pyshould'],
     test_suite='nose.collector',
     version='1.0.3',

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
     install_requires=[],
     tests_require=['nose', 'pyshould'],
     test_suite='nose.collector',
+    version='1.0.3',
     zip_safe=False,
 )


### PR DESCRIPTION
`python setup.py bdist_rpm` requires a valid `version` value in `setup.py` file.

With this change, we'll enable it by avoid having an string to interpolate to bump the version, but just replace the current version with the new one defined as **VERSION** env variable.

@drslump @franmrl  
