### PR TITLE
bump new version in setup.py@master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,8 @@ endif
 	# Package and upload to pypi
 	rm -rf dist && python setup.py sdist && twine upload dist/*
 
+	# Bring new version to master
 	git checkout master
+	git merge --ff ${VERSION}-release
+	git push origin master
 	git branch -D ${VERSION}-release


### PR DESCRIPTION
Upon uploading a new version to pypi, we were missing bringing the new version to master.
