### PR TITLE
Proper support for patching dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,6 @@ setup(
     url='https://www.github.com/telefonicaid/di-py',
     tests_require=['nose', 'pyshould'],
     test_suite='nose.collector',
-    version='1.0.3',
+    version='1.1.0',
     zip_safe=False,
 )


### PR DESCRIPTION
A common case when testing is changing the dependencies with mocks (ie via `PatchedDependencyMap`), however the way we had to apply it to the injector decorator was quite ugly via the `inject.dependencies` property.

Now the injector decorator exposes two methods `.patch` and `.unpatch`, they keep an internal stack of dependencies and the injection will always use the top-most one.

The use of the `.dependencies` property is still available but deprecated, once we do a major version release it should be completely removed.

Also included a bit of low-hanging fruit:
- warn instead of log when the decorator is not needed
- fail quickly if by mistake the decorator factory `injector` is used as decorator
