### PR TITLE
ProxyDependencyMap interface

### DIFF
--- a/di/__init__.py
+++ b/di/__init__.py
@@ -6,7 +6,9 @@
 from .main import (
     Key, injector, InjectorDescriptor, MetaInject,
     DependencyMap, ContextualDependencyMap, PatchedDependencyMap,
+    ProxyDependencyMap, InjectorProxy
 )
 
 __all__ = ['Key', 'injector', 'InjectorDescriptor', 'MetaInject',
-           'DependencyMap', 'ContextualDependencyMap', 'PatchedDependencyMap']
+           'DependencyMap', 'ContextualDependencyMap', 'PatchedDependencyMap',
+           'ProxyDependencyMap', 'InjectorProxy']

--- a/di/__init__.py
+++ b/di/__init__.py
@@ -6,9 +6,9 @@
 from .main import (
     Key, injector, InjectorDescriptor, MetaInject,
     DependencyMap, ContextualDependencyMap, PatchedDependencyMap,
-    ProxyDependencyMap, InjectorProxy
+    InjectorProxy
 )
 
 __all__ = ['Key', 'injector', 'InjectorDescriptor', 'MetaInject',
            'DependencyMap', 'ContextualDependencyMap', 'PatchedDependencyMap',
-           'ProxyDependencyMap', 'InjectorProxy']
+           'InjectorProxy']

--- a/tests/di_tests.py
+++ b/tests/di_tests.py
@@ -6,7 +6,7 @@
 import unittest
 from pyshould import should
 
-from di import injector, Key, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
+from di import injector, Key, ProxyDependencyMap, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
 
 
 class Ham(object):
@@ -309,6 +309,19 @@ class DependencyMapDescriptorTests(unittest.TestCase):
 
         dm[Ham] = None
         subject.ham | should.be_None
+
+class DependencyMapProxyTests(unittest.TestCase):
+
+    def test_acts_as_proxy(self):
+        dm = ProxyDependencyMap()
+        dm[Ham] = Ham()
+        dm[Spam] = Spam()
+
+        ham = dm(Ham)
+        spam = dm(Spam)
+
+        ham | should.be_a(Ham)
+        spam | should.be_a(Spam)
 
 
 class ContextualDependencyMapTests(unittest.TestCase):

--- a/tests/di_tests.py
+++ b/tests/di_tests.py
@@ -6,7 +6,7 @@
 import unittest
 from pyshould import should
 
-from di import injector, Key, ProxyDependencyMap, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
+from di import injector, Key, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
 
 
 class Ham(object):
@@ -125,6 +125,7 @@ class InjectorMetaclassTests(unittest.TestCase):
 
         class Foo(object):
             __metaclass__ = MetaInject(self.inject)
+
             def echo(self, test=Ham):
                 return test
 
@@ -310,18 +311,44 @@ class DependencyMapDescriptorTests(unittest.TestCase):
         dm[Ham] = None
         subject.ham | should.be_None
 
+
 class DependencyMapProxyTests(unittest.TestCase):
 
     def test_acts_as_proxy(self):
-        dm = ProxyDependencyMap()
+        dm = DependencyMap()
         dm[Ham] = Ham()
         dm[Spam] = Spam()
 
-        ham = dm(Ham)
-        spam = dm(Spam)
+        ham = dm.proxy(Ham)
+        spam = dm.proxy(Spam)
 
         ham | should.be_a(Ham)
         spam | should.be_a(Spam)
+
+    def test_proxy_bypassed_methods(self):
+        dm = DependencyMap()
+        dm[list] = list()
+
+        l = dm.proxy(list)
+        l.append(1)
+        l.append(3)
+        l[1] = 2
+
+        l[0] | should.eq(1)
+        l[1] | should.eq(2)
+        len(l) | should.eq(2)
+        (l == [1, 2]) | should.eq(True)
+        repr(l) | should.eq("[1, 2]")
+        str(l) | should.eq("[1, 2]")
+        (l + [3, 4]) | should.eq([1, 2, 3, 4])
+
+        # and so on ...
+
+    def test_proxy_dependency_missing(self):
+        dm = DependencyMap()
+        l = dm.proxy("hi")
+        with should.throw(LookupError):
+            l.foo()
 
 
 class ContextualDependencyMapTests(unittest.TestCase):
@@ -375,6 +402,7 @@ class PatchedDependencyMapTests(unittest.TestCase):
         self.map = ContextualDependencyMap()
         self.map[ContextualDependencyMap] = self.map
         self.inject = injector(self.map)
+
         @self.map.singleton(Ham)
         def fn(deps):
             return Ham()


### PR DESCRIPTION
This interface implements a Proxy pattern instead of the Descriptor
one. The idea is give to the developer the power of the di-py library
but hidden it to build class global variables.

A new ProxyDepencyMap class is able to generate InjectorProxy to act
as a Proxy of the proper instance given by the DependencyMap.

For example:

```
from di import ProxyDependencyMap
from .services import MyService

_dm = ProxyDependencyMap()

@_dm.singleton(MyService):
def _build_my_service(deps):
     return MyService()

my_service = _dm(MyService)
```
