### PR TITLE
Migrate to pytest and support PY3 syntax on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,13 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5.1"
   - "pypy"
 
 # command to install dependencies
 install:
   - "pip install ."
-  - "pip install nose"
-  - "pip install pyshould"
 
 # command to run tests
-script: nosetests
+script: python setup.py test
 

--- a/di/main.py
+++ b/di/main.py
@@ -56,6 +56,9 @@ class Key(object):
         else:
             self.value = value
 
+    def __hash__(self):
+        return hash(self.value)
+
     def __eq__(self, other):
         if isinstance(other, Key):
             return self.value == other.value

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,10 @@
 license = GNU AFFERO GENERAL version 3
 description-file = README.md
 license-file = LICENSE
+
+[aliases]
+test=pytest
+
+[tool:pytest]
+# Make sure we only include those files suffixed with -tests
+python_files = tests/*_tests.py

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import sys
 from setuptools import setup, find_packages
 
 try:
@@ -17,8 +18,8 @@ setup(
     name='di-py',
     packages=find_packages(exclude=['test*']),
     url='https://www.github.com/telefonicaid/di-py',
-    tests_require=['nose', 'pyshould'],
-    test_suite='nose.collector',
-    version='1.1.0',
+    setup_requires=['pytest-runner'] if 'test' in sys.argv else [],
+    tests_require=['pytest', 'pyshould'],
+    version='1.1.1',
     zip_safe=False,
 )

--- a/tests/di_tests.py
+++ b/tests/di_tests.py
@@ -3,12 +3,20 @@
 :license: see LICENSE for more details.
 """
 
+import sys
 import warnings
 
 import unittest
+import pytest
 from pyshould import should
 
 from di import injector, Key, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
+
+PY3 = sys.version_info[0] >= 3
+
+# Import tests using Python3 syntax
+if PY3:
+    from .py3 import *
 
 
 class Ham(object):
@@ -107,6 +115,7 @@ class InjectorErrorsTests(unittest.TestCase):
         foo = self.inject(lambda x: x, warn=False)
         foo(10) | should.be(10)
 
+    @pytest.mark.skipif(PY3, reason='Python 3 deprecates getargspec generating an extra warning')
     def test_warns_when_unneeded(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -124,15 +133,10 @@ class InjectorErrorsTests(unittest.TestCase):
             foo.bar()
 
 
+@pytest.mark.skipif(PY3, reason='requires python 2.x (meta-class syntax changes)')
 class InjectorMetaclassTests(unittest.TestCase):
 
     def setUp(self):
-        # Python 3 metaclass syntax is not compatible with Python 2.x
-        import sys
-        if sys.version_info[0] >= 3:
-            from nose.plugins.skip import SkipTest
-            raise SkipTest
-
         self.ham = Ham()
         self.map = {
             Ham: self.ham

--- a/tests/py3.py
+++ b/tests/py3.py
@@ -1,0 +1,32 @@
+"""
+This file contains tests that use PY3 syntax and would break the parser
+if loaded with PY2.
+
+Make sure the test runner doesn't collect this file automatically and that
+the symbols in this module are not shadowed by the ones in the main test file.
+
+:copyright: (c) 2013 by Telefonica I+D.
+:license: see LICENSE for more details.
+"""
+
+import unittest
+from pyshould import should
+
+from di import injector, Key
+
+KeyA = Key('A')
+KeyB = Key('B')
+KeyC = Key('C')
+
+
+def test_py3_kwonly():
+
+    inject = injector({KeyA: 'A', KeyB: 'B', KeyC: 'C'})
+
+    # While we don't fix the inject decorator we'll receive an error
+    with should.throw(ValueError):
+        @inject
+        def foo(a, b=KeyB, *args, c=KeyC):
+            pass
+
+


### PR DESCRIPTION
I'm finding [pytest](pytest.org) a much better solution for testing in python, the error reporting and fixture management are really great compared to _nose_.

In this change:
- migrate from _nose_ to pytest
- support tests using Python 3 syntax
- include Python 3.5.1 on the travis matrix (3.5.2 is not working)
- unrelated: make `Key` hasheable so it can be used with plain dicts
