### PR TITLE
Support Python 3 kwonlyargs

### DIFF
--- a/tests/di_tests.py
+++ b/tests/di_tests.py
@@ -109,13 +109,12 @@ class InjectorErrorsTests(unittest.TestCase):
             foo(self)
 
     def test_no_injectable_params(self):
-        foo = self.inject(lambda: True, warn=False)
+        foo = self.inject(lambda: True, __warn__=False)
         foo() | should.be_True
 
-        foo = self.inject(lambda x: x, warn=False)
+        foo = self.inject(lambda x: x, __warn__=False)
         foo(10) | should.be(10)
 
-    @pytest.mark.skipif(PY3, reason='Python 3 deprecates getargspec generating an extra warning')
     def test_warns_when_unneeded(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/tests/py3.py
+++ b/tests/py3.py
@@ -9,6 +9,8 @@ the symbols in this module are not shadowed by the ones in the main test file.
 :license: see LICENSE for more details.
 """
 
+from typing import Any
+
 import unittest
 from pyshould import should
 
@@ -19,14 +21,40 @@ KeyB = Key('B')
 KeyC = Key('C')
 
 
-def test_py3_kwonly():
+def test_py3_kwonlydefaults():
 
     inject = injector({KeyA: 'A', KeyB: 'B', KeyC: 'C'})
 
-    # While we don't fix the inject decorator we'll receive an error
-    with should.throw(ValueError):
-        @inject
-        def foo(a, b=KeyB, *args, c=KeyC):
-            pass
+    @inject
+    def foo(a, b=KeyB, *, c=KeyC):
+        return (b, c)
 
+    foo(10) | should.eql(('B', 'C'))
+
+    @inject
+    def bar(a, *, b=KeyB):
+        return b
+
+    bar(10) | should.eql('B')
+
+
+def test_py3_annotations():
+
+    class Foo: pass
+    class Bar: pass
+    class Baz: pass
+    class Qux: pass
+
+    inject = injector({Foo: Foo(), Bar: Bar(), Baz: Baz(), Qux: Qux()})
+
+    @inject
+    def foo(a: Foo = Key, b: Any = Bar, c: Baz = Baz, d=Qux):
+        return (a, b, c, d)
+
+    foo() | should.eql((
+        should.be_a(Foo),
+        should.be_a(Bar),
+        should.be_a(Baz),
+        should.be_a(Qux)
+    ))
 


### PR DESCRIPTION
Implements https://github.com/telefonicaid/di-py/pull/12
- Support Python3 keyword only defaults to define dependencies
- Experimental support for annotations by using `Key` as placeholder to trigger injection
