### PR TITLE
Fix test execution for Python 3.3 and 3.4

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,4 +8,4 @@ test=pytest
 
 [tool:pytest]
 # Make sure we only include those files suffixed with -tests
-python_files = tests/*_tests.py
+python_files = tests/test_*.py

--- a/tests/test_di.py
+++ b/tests/test_di.py
@@ -12,10 +12,11 @@ from pyshould import should
 
 from di import injector, Key, DependencyMap, ContextualDependencyMap, PatchedDependencyMap, MetaInject
 
-PY3 = sys.version_info[0] >= 3
+PY3 = sys.hexversion >= 0x03000000
+PY35 = sys.hexversion >= 0x03050000
 
-# Import tests using Python3 syntax
-if PY3:
+# Import tests using Python3 syntax when >=3.5
+if PY35:
     from .py3 import *
 
 


### PR DESCRIPTION
On https://github.com/telefonicaid/di-py/pull/15 the tests for Python 3.3 and 3.4 are failing due to incompatibilities of the tests with those versions.

This fixes the issue by ensuring that we only execute "Python 3" specific features when using 3.5 or above.